### PR TITLE
depracated sigmoid call

### DIFF
--- a/PyTorch/main.py
+++ b/PyTorch/main.py
@@ -262,7 +262,7 @@ class DS_out(nn.Module):
         self.layernorm = nn.LayerNorm(in_channels, eps=1e-5)
         self.conv1 = nn.Conv2d(in_channels, in_channels, 3, 1, padding="same")
         self.conv2 = nn.Conv2d(in_channels, in_channels, 3, 1, padding="same")
-        self.conv3 = nn.Conv2d(in_channels, 4, 3, 1, padding="same")
+        self.conv3 = nn.Conv2d(in_channels, out_channels, 3, 1, padding="same")
 
     def forward(self, x):
         x1 = self.upsample(x)

--- a/PyTorch/main.py
+++ b/PyTorch/main.py
@@ -271,7 +271,7 @@ class DS_out(nn.Module):
         x1 = x1.permute(0, 3, 1, 2)
         x1 = F.relu(self.conv1(x1))
         x1 = F.relu(self.conv2(x1))
-        out = F.sigmoid(self.conv3(x1))
+        out = torch.sigmoid(self.conv3(x1))
         
         return out
         


### PR DESCRIPTION
/usr/local/lib/python3.9/dist-packages/torch/nn/functional.py:1967: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
  warnings.warn("nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.")